### PR TITLE
feat: Add GitHub PR template and prompt

### DIFF
--- a/.github/prompts/create-pull-request.prompt.md
+++ b/.github/prompts/create-pull-request.prompt.md
@@ -1,0 +1,8 @@
+---
+mode: agent
+---
+
+## Create a concise and descriptive title for a pull request based on the following context and recent edits.
+
+Context: Path: .github/copilot-instructions.md
+Pull Request Template: .github/pull_request_template.md

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+## Summary
+<!-- Brief description of what this PR accomplishes -->
+
+## Link
+<!-- Related links: course section, documentation, issues, etc.
+    Remove this section if not applicable -->
+- Course: 
+- Documentation: 
+- Related Issue: 


### PR DESCRIPTION
## Summary
Add standardized GitHub pull request template and automated prompt for consistent PR descriptions across the OpenStack study project.

## Link
- Documentation: GitHub PR templates and automation best practices
- Related to project workflow standardization